### PR TITLE
Change a typo in the grammar description

### DIFF
--- a/Assignment2.md
+++ b/Assignment2.md
@@ -35,7 +35,7 @@ To create a parser for Propositional logic, we need a concrete representation of
 
 >ImplicationExpression -> OrExpression '=>' ImplicationExpression
 
->Implication -> OrExpression
+>ImplicationExpression -> OrExpression
 
 >OrExpression -> AndExpression '|' OrExpression
 


### PR DESCRIPTION
"Implication -> OrExpression" should be "ImplicationExpression -> OrExpression"; otherwise you infinitely recurse on the rule "ImplicationExpression -> OrExpression '=>' ImplicationExpression"
